### PR TITLE
feat: add configurable username

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,63 @@ This is a prometheus exporter which gives you metrics for how many emails you ha
 
 The exporter provides two metrics:
 
-`imap_entire_mails` is a gauge metric for how many emails are in this folder labeled with the foldername of your mailbox and your configured mailboxname  
-`imap_unseen_mails` is a gauge metric for how many emails are in this folder labeled with the foldername of your mailbox and your configured mailboxname 
+```output
+# HELP imap_entire_mails The total number of mails in folder
+# TYPE imap_entire_mails gauge
+imap_entire_mails{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 537
+imap_entire_mails{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1308
+imap_entire_mails{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
+imap_entire_mails{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 1
+imap_entire_mails{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 10
+imap_entire_mails{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 9
+# HELP imap_unseen_mails The total number of unseen mails in folder
+# TYPE imap_unseen_mails gauge
+imap_unseen_mails{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 2
+imap_unseen_mails{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 0
+imap_unseen_mails{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
+imap_unseen_mails{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 0
+imap_unseen_mails{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 0
+imap_unseen_mails{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 0
+```
 
 Metrics are available via http on port 8081/tcp on path `/metrics`.
 
 ## Configuration
 
-You can configure your accounts in a configfile in [toml](https://toml.io) format. You can find an example file in the folder `examples`. You can use
+You can configure your accounts in a configfile in [toml](https://toml.io) format. You can find the example file in the folder `examples`. You can use
 commandline flag `-config=<path/configfile`> to specify where your configfile is located.
+
+Example configuration, for one account, use only one account definition.
+
+```config
+# This is a example configfile. You need only one account configured, but all keys need to be defined (or empty if not yet implemented).
+# place this file named as config.toml in a folder named config along your imap-mailstat-exporter binary or mount this file as config.toml in folder /config/ in the container.
+# If you put you config elsewhere you can use the commandline flag -config=<path/configfile> to specify where your config is.
+
+[[Accounts]]
+name = "Jane Mailbox" # mailbox, you can set as you like, will be used as metric label (whitespace are replaced by underscore)
+mailaddress = "jane@example.com" # your email address (at the moment used as login name)
+username = "your_user_name" # if empty string mailaddress value is used
+password = "your_password" # beware of escaping characters like \ or "
+serveraddress = "mail.example.com" # mailserver name or address
+serverport = 993 # imap port number (at the moment only tls connection is supported)
+starttls = false # not yet implemented, will be available if you use STARTTLS
+additionalfolders = ["Trash", "Spam"] # additional mailfolders you want to have metrics for
+
+[[Accounts]] # you can configure more accounts if you like
+name = "Jane Doe Mailbox"
+mailaddress = "jane.doe@example.com"
+username = ""
+password = ""
+serveraddress = "mail.example.com"
+serverport = 993
+starttls = false
+additionalfolders = ["Trash", "Spam"]
+```
 
 This exporter is in early development and at the moment highly adjusted for my personal usecase.
 
 ## OCI Container Image
 
-Image is available on: `ghcr.io/bt909/imap-mailstat-exporter`.
+Image is available on: `ghcr.io/bt909/imap-mailstat-exporter`. At the moment there are no releases, just latest or you can use the digest.
+Releases will be available soon.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -5,8 +5,8 @@
 [[Accounts]]
 name = "Jane Mailbox" # mailbox, you can set as you like, will be used as metric label (whitespace are replaced by underscore)
 mailaddress = "jane@example.com" # your email address (at the moment used as login name)
-username = "" # not yet implemented
-password = "" # your password, beware of escaping characters like \ or "
+username = "your_user_name" # if empty string mailaddress value is used
+password = "your_password" # beware of escaping characters like \ or "
 serveraddress = "mail.example.com" # mailserver name or address
 serverport = 993 # imap port number (at the moment only tls connection is supported)
 starttls = false # not yet implemented, will be available if you use STARTTLS

--- a/internal/configread/configread.go
+++ b/internal/configread/configread.go
@@ -3,6 +3,7 @@ package configread
 
 import (
 	"os"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 )
@@ -35,5 +36,18 @@ func GetConfig(configfile string) MyConfig {
 	checkError(err)
 	var config MyConfig
 	err = toml.Unmarshal(file, &config)
+
+	sliceLength := len(config.Accounts)
+	var wg sync.WaitGroup
+	wg.Add(sliceLength)
+
+	for account := range config.Accounts {
+		go func(account int) {
+			defer wg.Done()
+			if config.Accounts[account].Username == "" {
+				config.Accounts[account].Username = config.Accounts[account].Mailaddress
+			}
+		}(account)
+	}
 	return config
 }

--- a/internal/valuecollect/valuecollector.go
+++ b/internal/valuecollect/valuecollector.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/client"
@@ -75,7 +76,7 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 	for account := range config.Accounts {
 		go func(account int) {
 			defer wg.Done()
-			fmt.Println("Fetch metrics for", config.Accounts[account].Mailaddress, "using server", config.Accounts[account].Serveraddress)
+			fmt.Println("Fetch metrics for", config.Accounts[account].Mailaddress, "using server", config.Accounts[account].Serveraddress, "at", time.Now().Format(time.RFC850))
 
 			var serverconnection strings.Builder
 			serverconnection.WriteString(config.Accounts[account].Serveraddress)
@@ -87,7 +88,7 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			defer c.Close()
 
-			if err := c.Login(config.Accounts[account].Mailaddress, config.Accounts[account].Password); err != nil {
+			if err := c.Login(config.Accounts[account].Username, config.Accounts[account].Password); err != nil {
 				log.Fatalf("failed to login: %v", err)
 			}
 


### PR DESCRIPTION
Username was set hard to configured mail address, which is fine in my use case, but this PR adds the possibility to configure an username which is not the same as mail address. 