### PR TITLE
BREAKING CHANGE: rename metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ Connections to IMAP are only TLS enrypted supported, either via TLS or STARTTLS.
 The exporter provides two metrics:
 
 ```output
-# HELP imap_mails_all_quantity The total number of mails in folder
-# TYPE imap_mails_all_quantity gauge
-imap_mails_all_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 537
-imap_mails_all_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1308
-imap_mails_all_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
-imap_mails_all_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 1
-imap_mails_all_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 10
-imap_mails_all_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 9
-# HELP imap_mails_unseen_quantity The total number of unseen mails in folder
-# TYPE imap_mails_unseen_quantity gauge
-imap_mails_unseen_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 2
-imap_mails_unseen_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 0
-imap_mails_unseen_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
-imap_mails_unseen_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 0
-imap_mails_unseen_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 0
-imap_mails_unseen_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 0
+# HELP imap_mailstat_mails_all_quantity The total number of mails in folder
+# TYPE imap_mailstat_mails_all_quantity gauge
+imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 537
+imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1308
+imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
+imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 1
+imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 10
+imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 9
+# HELP imap_mailstat_mails_unseen_quantity The total number of unseen mails in folder
+# TYPE imap_mailstat_mails_unseen_quantity gauge
+imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 2
+imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 0
+imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
+imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 0
+imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 0
+imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 0
 ```
 
 Metrics are available via http on port 8081/tcp on path `/metrics`.

--- a/internal/valuecollect/valuecollector.go
+++ b/internal/valuecollect/valuecollector.go
@@ -26,12 +26,12 @@ type imapStatsCollector struct {
 func NewImapStatsCollector() *imapStatsCollector {
 	return &imapStatsCollector{
 		allMails: prometheus.NewDesc(
-			prometheus.BuildFQName("imap", "mails_all", "quantity"),
+			prometheus.BuildFQName("imap_mailstat", "mails_all", "quantity"),
 			"The total number of mails in folder",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		unseenMails: prometheus.NewDesc(
-			prometheus.BuildFQName("imap", "mails_unseen", "quantity"),
+			prometheus.BuildFQName("imap_mailstat", "mails_unseen", "quantity"),
 			"The total number of unseen mails in folder",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),


### PR DESCRIPTION
Use the exporter name as part of the metric. If I ever will add some not imap related metrics, this is not confusing, as I use the exporter name as part of the metric series.