### PR TITLE
feat: switch to kingpinv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Unreleased
+
+* [BREAKING CHANGE]: change command line handling by switching command line parsing to [kingpin v2](https://github.com/alecthomas/kingpin) https://github.com/bt909/imap-mailstat-exporter/pull/32
+* [CHORE]: bump to golang 1.21 and rename some internal things https://github.com/bt909/imap-mailstat-exporter/pull/31
+* [CHORE]: update module github.com/prometheus/client_golang from v0.16.0 to v1.17.0 https://github.com/bt909/imap-mailstat-exporter/pull/30
+* [CHORE]: update module go.uber.org/zap from v1.25.0 to v1.26.0 https://github.com/bt909/imap-mailstat-exporter/pull/29
+
+# 0.0.1
+
+* [FEAT]: first release

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a prometheus exporter which gives you metrics for how many emails you ha
 Connections to IMAP are only TLS enrypted supported, either via TLS or STARTTLS.
 
 > [!NOTE]
-> This exporter is in early development and at the moment highly adjusted for my personal usecase.
+> This exporter is in early development and at the moment highly adjusted for my personal usecase. As it not reached 1.0.0 yet, there may are breaking changes at any time. Keep an eye on the [CHANGELOG](https://github.com/bt909/imap-mailstat-exporter/blob/main/CHANGELOG.md) for information.
 
 The exporter provides nine metrics, two main metrics are provided for all accounts, one metric can be enabled using a feature flag `-oldestunseendate` and six metrics are quota related and only provided if the server supports imap quota.
 
@@ -31,7 +31,7 @@ The exposed metrics are the following:
 `imap_mailstat_mails_messagequotaused_quantity` (only imap with quota support)  
 `imap_mailstat_mails_storagequotaavail_kilobytes` (only imap with quota support)  
 `imap_mailstat_mails_storagequotaused_kilobytes` (only imap with quota support)  
-`imap_mailstat_mails_oldestunseen_timestamp` (only with enabled feature flag `-oldestunseendate`)
+`imap_mailstat_mails_oldestunseen_timestamp` (only with enabled feature flag `--oldestunseen.feature`)
 
 Example output:
 
@@ -95,6 +95,28 @@ Metrics are available via http on port 8081/tcp on path `/metrics`.
 
 ## Commandline Options
 
+### version 0.1.0 (not yet released, about to come)
+
+You have three important commandline options. The information of the commandline flags can also be provided as environment variables.  
+
+```shell
+usage: imap-mailstat-exporter [<flags>]
+
+a prometheus-exporter to expose metrics about your mailboxes
+
+
+Flags:
+  -h, --[no-]help         Show context-sensitive help (also try --help-long and --help-man).
+  -c, --config.file="./config/config.toml"  
+                          provide the configfile ($MAILSTAT_EXPORTER_CONFIGFILE)
+      --log.level="INFO"  provide the desired loglevel, INFO and ERROR are supported ($MAILSTAT_EXPORTER_LOGLEVEL)
+      --[no-]oldestunseen.feature  
+                          enable metric with timestamp of oldest unseen mail, default false ($MAILSTAT_EXPORTER_OLDESTUNSEEN)
+  -v, --[no-]version      Show application version.
+```
+
+### Version 0.0.1
+
 You have three available commandline options.
 
 ```shell
@@ -110,7 +132,7 @@ Usage of imap-mailstat-exporter:
 ## Configuration
 
 You can configure your accounts in a configfile in [toml](https://toml.io) format. You can find the example file in the folder `examples`. You can use
-commandline flag `-config=<path/configfile` to specify where your configfile is located.
+commandline flag `-config=<path/configfile>` (version 0.0.1) or `--config.file="<path/configfile>"` (version 0.1.0, not yet released) to specify where your configfile is located.
 
 > [!IMPORTANT]
 > If you are using the container image, the default configfile used where you need to mount your config is `/home/nonroot/config/config.toml`.
@@ -121,7 +143,7 @@ Example configuration, for one account, use only one account definition.
 # This is a example configfile.  
 # You need only one account configured, but all keys need to be defined except username which can be empty and mailaddress is used as username value instead.
 # place this file named as config.toml in a folder named config along your imap-mailstat-exporter binary or mount this file as config.toml in folder /config/ in the container.
-# If you put you config elsewhere you can use the commandline flag -config=<path/configfile> to specify where your config is.
+# If you put you config elsewhere you can use the commandline flag --config.file="<path/configfile>" to specify where your config is.
 
 [[Accounts]]
 name = "Jane Mailbox" # mailbox, you can set as you like, will be used as metric label (whitespace are replaced by underscore)
@@ -147,7 +169,7 @@ additionalfolders = ["Trash", "Spam"]
 ## Loglevel
 
 At the moment INFO (default) and ERROR are available. INFO tells you when metrics are fetched and give you additional information how long the connection setup, the login process and the whole metric fetch takes.
-If INFO is too noisy you can switch to ERROR level and only get information about errors by using commandline flag `-loglevel ERROR`.
+If INFO is too noisy you can switch to ERROR level and only get information about errors by using commandline flag `-loglevel ERROR` (version 0.0.1), or `--log.level="ERROR"` (version 0.1.0, not yet released).
 
 ## OCI Container Image
 
@@ -156,6 +178,8 @@ Image is available on: `ghcr.io/bt909/imap-mailstat-exporter`. Images are build 
 ```shell
 docker pull ghcr.io/bt909/imap-mailstat-exporter:*.*.*
 ```
+
+The tag `latest` is following main branch and not related to the releases. This behavior will stay until release 1.0.0.
 
 ## License
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,7 +1,7 @@
 # This is a example configfile.  
 # You need only one account configured, but all keys need to be defined except username which can be empty and mailaddress is used as username value instead.
 # place this file named as config.toml in a folder named config along your imap-mailstat-exporter binary or mount this file as config.toml in folder /config/ in the container.
-# If you put you config elsewhere you can use the commandline flag -config=<path/configfile> to specify where your config is.
+# If you put you config elsewhere you can use the commandline flag --config.file="<path/configfile>" to specify where your config is.
 
 [[Accounts]]
 name = "Jane Mailbox" # mailbox, you can set as you like, will be used as metric label (whitespace are replaced by underscore)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.3.2
+	github.com/alecthomas/kingpin/v2 v2.3.2
 	github.com/emersion/go-imap v1.2.1
 	github.com/emersion/go-imap-quota v0.0.0-20210203125329-619074823f3c
 	github.com/prometheus/client_golang v1.17.0
@@ -11,6 +12,7 @@ require (
 )
 
 require (
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 // indirect
@@ -19,6 +21,7 @@ require (
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,14 @@
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/alecthomas/kingpin/v2 v2.3.2 h1:H0aULhgmSzN8xQ3nX1uxtdlTHYoPLu5AhHxWrKI6ocU=
+github.com/alecthomas/kingpin/v2 v2.3.2/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
@@ -35,8 +40,12 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
@@ -56,5 +65,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/valuecollect/valuecollector.go
+++ b/internal/valuecollect/valuecollector.go
@@ -232,6 +232,8 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			utils.Logger.Info("IMAP Login", zap.String("duration:", fmt.Sprint(time.Since(startLogin))), zap.String("address", config.Accounts[account].Mailaddress))
 
+			defer c.Logout()
+
 			selectedInbox, err := c.Select("INBOX", true)
 			if err != nil {
 				utils.Logger.Error("failed to select", zap.String("folder", "Inbox"), zap.Error(err))
@@ -331,10 +333,6 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 			}
 
-			if err := c.Logout(); err != nil {
-				utils.Logger.Error("failed to logout", zap.String("address", fmt.Sprint(config.Accounts[account].Mailaddress)), zap.Error(err))
-				return
-			}
 			utils.Logger.Info("Metric fetch", zap.String("duration:", fmt.Sprint(time.Since(start))), zap.String("address", config.Accounts[account].Mailaddress))
 		}(account)
 	}


### PR DESCRIPTION
To prepare to switch to [exporter toolkit](https://github.com/prometheus/exporter-toolkit) to provide a prometheus-way of look and feel of the exporter, I started to switch to [Kingpin v2](https://github.com/alecthomas/kingpin), as this is used widely in the prometheus community and is also used by the exporter-toolkit.
This will be the first step towards the toolkit.