### PR TITLE
BREAKING CHANGE: rename metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Unreleased
 
+This version has some heavy changes, but these were things a thought about for a while now and think this shouldn't be deferred for a long time. So now we have a big bang but the next ideas I have in mind are not that destructive.
+
+* [BREAKING CHANGE]: rename metrics for readability and follow some best practices https://github.com/bt909/imap-mailstat-exporter/pull/36
 * [BREAKING CHANGE]: change logging behavior by switching to [exporter-toolkit](https://github.com/prometheus/exporter-toolkit) and removing go.uber.org/zap as logging framework https://github.com/bt909/imap-mailstat-exporter/pull/33
 * [BREAKING CHANGE]: change command line handling by switching command line parsing to [kingpin v2](https://github.com/alecthomas/kingpin) https://github.com/bt909/imap-mailstat-exporter/pull/32
 
+* [FEATURE]: add a new metric named mailstat_fetch_duration_seconds https://github.com/bt909/imap-mailstat-exporter/pull/36
 * [FEATURE]: add basic auth and http/2 (TLS secured) connection by using exporter-toolkit https://github.com/bt909/imap-mailstat-exporter/pull/33
 * [FEATURE]: add possibility to configure metrics path and listen address and port by using exporter-toolkit https://github.com/bt909/imap-mailstat-exporter/pull/33
 * [CHORE]: update module github.com/prometheus/common to from v0.44.0 to v0.45.0 https://github.com/bt909/imap-mailstat-exporter/pull/34

--- a/README.md
+++ b/README.md
@@ -36,22 +36,24 @@ The exposed metrics were the following in version 0.0.1 and can be enabled by us
 `imap_mailstat_mails_oldestunseen_timestamp` (only with enabled feature flag `--oldestunseen.feature`)
 
 > [!IMPORTANT]
-> In version 0.1.0 (not yet released) the metric names were changed. First because they were hard to read and now I hope I follow more best practices in naming metrics. As 0.1.0 comes with more than one breaking change my decision was to rename the metrics at this point as well. The exporter allows you for migration to get the old metrics as well using commandline flag `--migration.mode` or the also available environment variable `MAILSTAT_EXPORTER_MIGRATIONMODE=true`. This flag/variable and the old metrics will be removed in 0.2.0. 
+> In version 0.1.0 (not yet released) the metric names were changed. First because they were hard to read and now I hope I follow more best practices in naming metrics. As 0.1.0 comes with more than one breaking change my decision was to rename the metrics at this point as well. The exporter allows you for migration to get the old metrics as well using commandline flag `--migration.mode` or the also available environment variable `MAILSTAT_EXPORTER_MIGRATIONMODE=true`. This flag/variable and the old metrics will be removed in 0.2.0.
 
 The exposed metrics since 0.1.0 (not yet released) are the following:
 
-`mailstat_fetch_duration_seconds`  
-`mailstat_mails_all`  
-`mailstat_mails_unseen`  
-`mailstat_level_quota_avail` (only imap with quota support)  
-`mailstat_level_quota_used` (only imap with quota support)  
-`mailstat_mailbox_quota_avail` (only imap with quota support)  
-`mailstat_mailbox_quota_used` (only imap with quota support)  
-`mailstat_message_quota_avail` (only imap with quota support)  
-`mailstat_message_quota_used` (only imap with quota support)  
-`mailstat_storage_quota_avail_bytes` (only imap with quota support)  
-`mailstat_storage_quota_used_bytes` (only imap with quota support)  
-`mailstat_mails_oldest_unseen_timestamp` (only with enabled feature flag `--oldestunseen.feature`)  
+metric | type | description | remarks
+-------|------|-------------|---------
+`mailstat_fetch_duration_seconds` | gauge |Duration for fetching the metrics for the given account |
+`mailstat_mails_all` | gauge | The total number of mails in folder |
+`mailstat_mails_unseen` | gauge | The total number of unseen mails in folder |
+`mailstat_level_quota_avail` | gauge | How many levels are available according your quota | only imap with quota support
+`mailstat_level_quota_used` | gauge | How many levels are used | only imap with quota support
+`mailstat_mailbox_quota_avail` | gauge | How many mailboxes are available according your quota | only imap with quota support
+`mailstat_mailbox_quota_used` | gauge |  How many mailboxes are used | only imap with quota support
+`mailstat_message_quota_avail` | gauge | How many messages available according your quota | only imap with quota support
+`mailstat_message_quota_used` | gauge | How many messages are used | only imap with quota support
+`mailstat_storage_quota_avail_bytes` | gauge | How many storage is available according your quota | only imap with quota support
+`mailstat_storage_quota_used_bytes` | gauge | How many storage is used | only imap with quota support
+`mailstat_mails_oldest_unseen_timestamp` | gauge | Timestamp in unix format of oldest unseen mail | only with enabled feature flag `--oldestunseen.feature`  
 
 Example output:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Connections to IMAP are only TLS enrypted supported, either via TLS or STARTTLS.
 
 As this exporter is using [exporter-toolkit](https://github.com/prometheus/exporter-toolkit) since 0.1.0 (not yet released), you can also configure basic auth, or TLS secured connection to the exporter using http/2, for more information visit the [configuration page of exporter-toolkit](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md).
 
-The exporter provides nine metrics, two main metrics are provided for all accounts, one metric can be enabled using a feature flag `--oldestunseen.feature` and six metrics are quota related and only provided if the server supports imap quota.
+The exporter provides ten metrics, three main metrics are provided for all accounts, one metric can be enabled using a feature flag `--oldestunseen.feature` and six metrics are quota related and only provided if the server supports imap quota.
 
 If your account supports quota you can see in loglevel INFO (default) with the following log entry:
 
@@ -21,7 +21,7 @@ ts=2023-10-30T22:12:27.376Z caller=valuecollector.go:266 level=info msg="Fetchin
 
 ```
 
-The exposed metrics are the following:
+The exposed metrics were the following in version 0.0.1 and can be enabled by using commandline flag `--migration.mode`:
 
 `imap_mailstat_mails_all_quantity`  
 `imap_mailstat_mails_unseen_quantity`  
@@ -35,62 +35,76 @@ The exposed metrics are the following:
 `imap_mailstat_mails_storagequotaused_kilobytes` (only imap with quota support)  
 `imap_mailstat_mails_oldestunseen_timestamp` (only with enabled feature flag `--oldestunseen.feature`)
 
+> [!IMPORTANT]
+> In version 0.1.0 (not yet released) the metric names were changed. First because they were hard to read and now I hope I follow more best practices in naming metrics. As 0.1.0 comes with more than one breaking change my decision was to rename the metrics at this point as well. The exporter allows you for migration to get the old metrics as well using commandline flag `--migration.mode` or the also available environment variable `MAILSTAT_EXPORTER_MIGRATIONMODE=true`. This flag/variable and the old metrics will be removed in 0.2.0. 
+
+The exposed metrics since 0.1.0 (not yet released) are the following:
+
+`mailstat_fetch_duration_seconds`  
+`mailstat_mails_all`  
+`mailstat_mails_unseen`  
+`mailstat_level_quota_avail` (only imap with quota support)  
+`mailstat_level_quota_used` (only imap with quota support)  
+`mailstat_mailbox_quota_avail` (only imap with quota support)  
+`mailstat_mailbox_quota_used` (only imap with quota support)  
+`mailstat_message_quota_avail` (only imap with quota support)  
+`mailstat_message_quota_used` (only imap with quota support)  
+`mailstat_storage_quota_avail_bytes` (only imap with quota support)  
+`mailstat_storage_quota_used_bytes` (only imap with quota support)  
+`mailstat_mails_oldest_unseen_timestamp` (only with enabled feature flag `--oldestunseen.feature`)  
+
 Example output:
 
 ```output
-# HELP imap_mailstat_mails_all_quantity The total number of mails in folder
-# TYPE imap_mailstat_mails_all_quantity gauge
-imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 537
-imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1308
-imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
-imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 1
-imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 10
-imap_mailstat_mails_all_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 9
-# HELP imap_mailstat_mails_levelquotaavail_quantity How many levels are available according your quota
-# TYPE imap_mailstat_mails_levelquotaavail_quantity gauge
-imap_mailstat_mails_levelquotaavail_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 3
-imap_mailstat_mails_levelquotaavail_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 3
-# HELP imap_mailstat_mails_levelquotaused_quantity How many levels are used
-# TYPE imap_mailstat_mails_levelquotaused_quantity gauge
-imap_mailstat_mails_levelquotaused_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 1
-imap_mailstat_mails_levelquotaused_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1
-# HELP imap_mailstat_mails_mailboxquotaavail_quantity How many mailboxes are available according your quota
-# TYPE imap_mailstat_mails_mailboxquotaavail_quantity gauge
-imap_mailstat_mails_mailboxquotaavail_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 31
-imap_mailstat_mails_mailboxquotaavail_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 31
-# HELP imap_mailstat_mails_mailboxquotaused_quantity How many mailboxes are used
-# TYPE imap_mailstat_mails_mailboxquotaused_quantity gauge
-imap_mailstat_mails_mailboxquotaused_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 0
-imap_mailstat_mails_mailboxquotaused_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 0
-# HELP imap_mailstat_mails_messagequotaavail_quantity How many messages available according your quota
-# TYPE imap_mailstat_mails_messagequotaavail_quantity gauge
-imap_mailstat_mails_messagequotaavail_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 62000
-imap_mailstat_mails_messagequotaavail_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 62000
-# HELP imap_mailstat_mails_messagequotaused_quantity How many messages are used
-# TYPE imap_mailstat_mails_messagequotaused_quantity gauge
-imap_mailstat_mails_messagequotaused_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 2
-imap_mailstat_mails_messagequotaused_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 4
-# HELP imap_mailstat_mails_oldestunseen_timestamp Timestamp in unix format of oldest unseen mail
-# TYPE imap_mailstat_mails_oldestunseen_timestamp gauge
-imap_mailstat_mails_oldestunseen_timestamp{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 1.693660714e+09
-imap_mailstat_mails_oldestunseen_timestamp{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1.694538222e+09
-imap_mailstat_mails_oldestunseen_timestamp{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 1.69398128e+09
-# HELP imap_mailstat_mails_storagequotaavail_kilobytes How many storage is available according your quota
-# TYPE imap_mailstat_mails_storagequotaavail_kilobytes gauge
-imap_mailstat_mails_storagequotaavail_kilobytes{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 1.048576e+06
-imap_mailstat_mails_storagequotaavail_kilobytes{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1.048576e+06
-# HELP imap_mailstat_mails_storagequotaused_kilobytes How many storage is used
-# TYPE imap_mailstat_mails_storagequotaused_kilobytes gauge
-imap_mailstat_mails_storagequotaused_kilobytes{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 35
-imap_mailstat_mails_storagequotaused_kilobytes{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 71
-# HELP imap_mailstat_mails_unseen_quantity The total number of unseen mails in folder
-# TYPE imap_mailstat_mails_unseen_quantity gauge
-imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 2
-imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 0
-imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
-imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 0
-imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 0
-imap_mailstat_mails_unseen_quantity{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 0
+# HELP mailstat_fetch_duration_seconds Duration for fetching the metrics for the given account
+# TYPE mailstat_fetch_duration_seconds gauge
+mailstat_fetch_duration_seconds{mailboxname="Jane_Doe_Mailbox"} 1.303695723
+mailstat_fetch_duration_seconds{mailboxname="Jane_Mailbox"} 0.612008505
+# HELP mailstat_level_quota_avail How many levels are available according your quota
+# TYPE mailstat_level_quota_avail gauge
+mailstat_level_quota_avail{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 3000
+# HELP mailstat_level_quota_used How many levels are used
+# TYPE mailstat_level_quota_used gauge
+mailstat_level_quota_used{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 1000
+# HELP mailstat_mailbox_quota_avail How many mailboxes are available according your quota
+# TYPE mailstat_mailbox_quota_avail gauge
+mailstat_mailbox_quota_avail{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 31000
+# HELP mailstat_mailbox_quota_used How many mailboxes are used
+# TYPE mailstat_mailbox_quota_used gauge
+mailstat_mailbox_quota_used{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 0
+# HELP mailstat_mails_all The total number of mails in folder
+# TYPE mailstat_mails_all gauge
+mailstat_mails_all{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 404
+mailstat_mails_all{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 2
+mailstat_mails_all{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 5
+mailstat_mails_all{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
+mailstat_mails_all{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 32
+mailstat_mails_all{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 0
+# HELP mailstat_mails_oldest_unseen_timestamp Timestamp in unix format of oldest unseen mail
+# TYPE mailstat_mails_oldest_unseen_timestamp gauge
+mailstat_mails_oldest_unseen_timestamp{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1.69878845e+09
+mailstat_mails_oldest_unseen_timestamp{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 1.698318945e+09
+# HELP mailstat_mails_unseen The total number of unseen mails in folder
+# TYPE mailstat_mails_unseen gauge
+mailstat_mails_unseen{mailboxfoldername="INBOX",mailboxname="Jane_Doe_Mailbox"} 1
+mailstat_mails_unseen{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 0
+mailstat_mails_unseen{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Doe_Mailbox"} 5
+mailstat_mails_unseen{mailboxfoldername="INBOX_Spam",mailboxname="Jane_Mailbox"} 0
+mailstat_mails_unseen{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Doe_Mailbox"} 0
+mailstat_mails_unseen{mailboxfoldername="INBOX_Trash",mailboxname="Jane_Mailbox"} 0
+# HELP mailstat_message_quota_avail How many messages available according your quota
+# TYPE mailstat_message_quota_avail gauge
+mailstat_message_quota_avail{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 6.2e+07
+# HELP mailstat_message_quota_used How many messages are used
+# TYPE mailstat_message_quota_used gauge
+mailstat_message_quota_used{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 2000
+# HELP mailstat_storage_quota_avail_bytes How many storage is available according your quota
+# TYPE mailstat_storage_quota_avail_bytes gauge
+mailstat_storage_quota_avail_bytes{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 1.048576e+09
+# HELP mailstat_storage_quota_used_bytes How many storage is used
+# TYPE mailstat_storage_quota_used_bytes gauge
+mailstat_storage_quota_used_bytes{mailboxfoldername="INBOX",mailboxname="Jane_Mailbox"} 35000
+
 ```
 
 Metrics are available via http (or https if configured) on port 8081/tcp on path `/metrics` as default, but you can configure this of you want to change.
@@ -113,6 +127,7 @@ Flags:
                                  Provide the configfile ($MAILSTAT_EXPORTER_CONFIGFILE)
       --[no-]oldestunseen.feature  
                                  Enable metric with timestamp of oldest unseen mail, default false ($MAILSTAT_EXPORTER_OLDESTUNSEEN)
+      --[no-]migration.mode      Enable old metric format, default false, WILL BE REMOVED IN version 0.2.0 ($MAILSTAT_EXPORTER_MIGRATIONMODE)
       --[no-]web.systemd-socket  Use systemd socket activation listeners instead of port listeners (Linux only).
       --web.listen-address=:8081 ...  
                                  Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.

--- a/cmd/imap-mailstat-exporter/main.go
+++ b/cmd/imap-mailstat-exporter/main.go
@@ -19,9 +19,10 @@ import (
 
 var (
 	name                = "imap-mailstat-exporter"
-	Version             = "0.1.0-alpha"
+	Version             = "0.1.0-beta"
 	configfile          *string
 	oldestunseenfeature *bool
+	migrationmode       *bool
 	logger              = promlog.New(&promlog.Config{})
 )
 
@@ -31,6 +32,7 @@ func main() {
 	var app = kingpin.New(name, "a prometheus-exporter to expose metrics about your mailboxes")
 	configfile = app.Flag("config.file", "Provide the configfile").Envar("MAILSTAT_EXPORTER_CONFIGFILE").Default("./config/config.toml").Short('c').String()
 	oldestunseenfeature = app.Flag("oldestunseen.feature", "Enable metric with timestamp of oldest unseen mail, default false").Envar("MAILSTAT_EXPORTER_OLDESTUNSEEN").Default("false").Bool()
+	migrationmode = app.Flag("migration.mode", "Enable old metric format, default false, WILL BE REMOVED IN version 0.2.0").Envar("MAILSTAT_EXPORTER_MIGRATIONMODE").Default("false").Bool()
 	toolkitFlags := kingpinflag.AddFlags(app, ":8081")
 	metricsPath := app.Flag("web.telemetry-path", "Path under which to expose the IMAP mailstat Prometheus metrics").Envar("MAILSTAT_EXPORTER_WEB_TELEMETRY_PATH").Default("/metrics").String()
 	app.Version(Version)
@@ -47,7 +49,7 @@ func main() {
 	level.Info(logger).Log("msg", "Starting imap-mailstat-exporter", "Version", Version)
 
 	reg := prometheus.NewRegistry()
-	d := valuecollect.NewImapStatsCollector(*configfile, logger, *oldestunseenfeature)
+	d := valuecollect.NewImapStatsCollector(*configfile, logger, *oldestunseenfeature, *migrationmode)
 	reg.MustRegister(d)
 
 	mux := http.NewServeMux()

--- a/internal/valuecollect/valuecollector.go
+++ b/internal/valuecollect/valuecollector.go
@@ -20,76 +20,149 @@ import (
 )
 
 type imapStatsCollector struct {
-	allMails            *prometheus.Desc
-	unseenMails         *prometheus.Desc
-	mailboxQuotaUsed    *prometheus.Desc
-	mailboxQuotaAvail   *prometheus.Desc
-	levelQuotaUsed      *prometheus.Desc
-	levelQuotaAvail     *prometheus.Desc
-	storageQuotaUsed    *prometheus.Desc
-	storageQuotaAvail   *prometheus.Desc
-	messageQuotaUsed    *prometheus.Desc
-	messageQuotaAvail   *prometheus.Desc
-	oldestUnseen        *prometheus.Desc
-	configfile          string
-	logger              log.Logger
-	oldestunseenfeature bool
+	allMails             *prometheus.Desc
+	unseenMails          *prometheus.Desc
+	mailboxQuotaUsed     *prometheus.Desc
+	mailboxQuotaAvail    *prometheus.Desc
+	levelQuotaUsed       *prometheus.Desc
+	levelQuotaAvail      *prometheus.Desc
+	storageQuotaUsed     *prometheus.Desc
+	storageQuotaAvail    *prometheus.Desc
+	messageQuotaUsed     *prometheus.Desc
+	messageQuotaAvail    *prometheus.Desc
+	oldestUnseen         *prometheus.Desc
+	fetchDuration        *prometheus.Desc
+	allMailsOld          *prometheus.Desc
+	unseenMailsOld       *prometheus.Desc
+	mailboxQuotaUsedOld  *prometheus.Desc
+	mailboxQuotaAvailOld *prometheus.Desc
+	levelQuotaUsedOld    *prometheus.Desc
+	levelQuotaAvailOld   *prometheus.Desc
+	storageQuotaUsedOld  *prometheus.Desc
+	storageQuotaAvailOld *prometheus.Desc
+	messageQuotaUsedOld  *prometheus.Desc
+	messageQuotaAvailOld *prometheus.Desc
+	oldestUnseenOld      *prometheus.Desc
+	configfile           string
+	logger               log.Logger
+	oldestunseenfeature  bool
+	migrationmode        bool
 }
 
 // provide metric "layout"
-func NewImapStatsCollector(configfile string, logger log.Logger, oldestunseenfeature bool) *imapStatsCollector {
+func NewImapStatsCollector(configfile string, logger log.Logger, oldestunseenfeature bool, migrationmode bool) *imapStatsCollector {
 	return &imapStatsCollector{
 		allMails: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_all", "quantity"),
+			prometheus.BuildFQName("mailstat", "mails", "all"),
 			"The total number of mails in folder",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		unseenMails: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_unseen", "quantity"),
+			prometheus.BuildFQName("mailstat", "mails", "unseen"),
 			"The total number of unseen mails in folder",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		mailboxQuotaUsed: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_mailboxquotaused", "quantity"),
+			prometheus.BuildFQName("mailstat", "mailbox_quota", "used"),
 			"How many mailboxes are used",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		mailboxQuotaAvail: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_mailboxquotaavail", "quantity"),
+			prometheus.BuildFQName("mailstat", "mailbox_quota", "avail"),
 			"How many mailboxes are available according your quota",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		levelQuotaUsed: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_levelquotaused", "quantity"),
+			prometheus.BuildFQName("mailstat", "level_quota", "used"),
 			"How many levels are used",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		levelQuotaAvail: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_levelquotaavail", "quantity"),
+			prometheus.BuildFQName("mailstat", "level_quota", "avail"),
 			"How many levels are available according your quota",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		storageQuotaUsed: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_storagequotaused", "kilobytes"),
+			prometheus.BuildFQName("mailstat", "storage_quota", "used_bytes"),
 			"How many storage is used",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		storageQuotaAvail: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_storagequotaavail", "kilobytes"),
+			prometheus.BuildFQName("mailstat", "storage_quota", "avail_bytes"),
 			"How many storage is available according your quota",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		messageQuotaUsed: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_messagequotaused", "quantity"),
+			prometheus.BuildFQName("mailstat", "message_quota", "used"),
 			"How many messages are used",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		messageQuotaAvail: prometheus.NewDesc(
-			prometheus.BuildFQName("imap_mailstat", "mails_messagequotaavail", "quantity"),
+			prometheus.BuildFQName("mailstat", "message_quota", "avail"),
 			"How many messages available according your quota",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
 		),
 		oldestUnseen: prometheus.NewDesc(
+			prometheus.BuildFQName("mailstat", "mails", "oldest_unseen_timestamp"),
+			"Timestamp in unix format of oldest unseen mail",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		fetchDuration: prometheus.NewDesc(
+			prometheus.BuildFQName("mailstat", "fetch", "duration_seconds"),
+			"Duration for fetching the metrics for the given account",
+			[]string{"mailboxname"}, nil,
+		),
+		allMailsOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_all", "quantity"),
+			"The total number of mails in folder",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		unseenMailsOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_unseen", "quantity"),
+			"The total number of unseen mails in folder",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		mailboxQuotaUsedOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_mailboxquotaused", "quantity"),
+			"How many mailboxes are used",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		mailboxQuotaAvailOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_mailboxquotaavail", "quantity"),
+			"How many mailboxes are available according your quota",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		levelQuotaUsedOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_levelquotaused", "quantity"),
+			"How many levels are used",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		levelQuotaAvailOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_levelquotaavail", "quantity"),
+			"How many levels are available according your quota",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		storageQuotaUsedOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_storagequotaused", "kilobytes"),
+			"How many storage is used",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		storageQuotaAvailOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_storagequotaavail", "kilobytes"),
+			"How many storage is available according your quota",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		messageQuotaUsedOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_messagequotaused", "quantity"),
+			"How many messages are used",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		messageQuotaAvailOld: prometheus.NewDesc(
+			prometheus.BuildFQName("imap_mailstat", "mails_messagequotaavail", "quantity"),
+			"How many messages available according your quota",
+			[]string{"mailboxname", "mailboxfoldername"}, nil,
+		),
+		oldestUnseenOld: prometheus.NewDesc(
 			prometheus.BuildFQName("imap_mailstat", "mails_oldestunseen", "timestamp"),
 			"Timestamp in unix format of oldest unseen mail",
 			[]string{"mailboxname", "mailboxfoldername"}, nil,
@@ -97,6 +170,7 @@ func NewImapStatsCollector(configfile string, logger log.Logger, oldestunseenfea
 		configfile:          configfile,
 		logger:              logger,
 		oldestunseenfeature: oldestunseenfeature,
+		migrationmode:       migrationmode,
 	}
 
 }
@@ -158,11 +232,11 @@ func getMailboxUsed(qc *quota.Client, mailbox *imap.MailboxStatus, logger log.Lo
 		level.Error(logger).Log("msg", "Error in getting quota for INBOX", "mailboxname", mailboxname)
 	}
 
-	// put quota values in return values (index 0 is used, index 1 is available)
+	// put quota values in return values (index 0 is used, index 1 is available, convert from kilobytes to bytes as common prometheus unit)
 	for _, quota := range quotas {
 		for name, usage := range quota.Resources {
-			mailboxUsed[name+"_used"] = usage[0]
-			mailboxAvail[name+"_avail"] = usage[1]
+			mailboxUsed[name+"_used"] = usage[0] * 1000
+			mailboxAvail[name+"_avail"] = usage[1] * 1000
 		}
 	}
 
@@ -182,6 +256,18 @@ func (valuecollector *imapStatsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- valuecollector.messageQuotaUsed
 	ch <- valuecollector.messageQuotaAvail
 	ch <- valuecollector.oldestUnseen
+	ch <- valuecollector.fetchDuration
+	ch <- valuecollector.allMailsOld
+	ch <- valuecollector.unseenMailsOld
+	ch <- valuecollector.mailboxQuotaUsedOld
+	ch <- valuecollector.mailboxQuotaAvailOld
+	ch <- valuecollector.levelQuotaUsedOld
+	ch <- valuecollector.levelQuotaAvailOld
+	ch <- valuecollector.storageQuotaUsedOld
+	ch <- valuecollector.storageQuotaAvailOld
+	ch <- valuecollector.messageQuotaUsedOld
+	ch <- valuecollector.messageQuotaAvailOld
+	ch <- valuecollector.oldestUnseenOld
 }
 
 // collect values and put them in metrics channel
@@ -245,17 +331,26 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 			var metricnameSeenInbox []string
 			metricnameSeenInbox = append(metricnameSeenInbox, metricSeenInbox, namespaceSeenInBox)
 			ch <- prometheus.MustNewConstMetric(valuecollector.allMails, prometheus.GaugeValue, float64(countAllmailsInbox), metricnameSeenInbox...)
+			if valuecollector.migrationmode {
+				ch <- prometheus.MustNewConstMetric(valuecollector.allMailsOld, prometheus.GaugeValue, float64(countAllmailsInbox), metricnameSeenInbox...)
+			}
 
 			metricUnseenInbox, namespaceUnseenInbox, countUnseenInbox, _ := countUnseen(c, selectedInbox, valuecollector.logger, config.Accounts[account].Name, valuecollector.oldestunseenfeature)
 			var metricnameUnseenInbox []string
 			metricnameUnseenInbox = append(metricnameUnseenInbox, metricUnseenInbox, namespaceUnseenInbox)
 			ch <- prometheus.MustNewConstMetric(valuecollector.unseenMails, prometheus.GaugeValue, float64(countUnseenInbox), metricnameUnseenInbox...)
+			if valuecollector.migrationmode {
+				ch <- prometheus.MustNewConstMetric(valuecollector.unseenMailsOld, prometheus.GaugeValue, float64(countUnseenInbox), metricnameUnseenInbox...)
+			}
 
 			metricOldestUnseenInbox, namespaceOldestUnseenInbox, _, timestampOldestUnseenInbox := countUnseen(c, selectedInbox, valuecollector.logger, config.Accounts[account].Name, valuecollector.oldestunseenfeature)
 			var metricnameOldestUnseenInbox []string
 			if timestampOldestUnseenInbox > 0 {
 				metricnameOldestUnseenInbox = append(metricnameOldestUnseenInbox, metricOldestUnseenInbox, namespaceOldestUnseenInbox)
 				ch <- prometheus.MustNewConstMetric(valuecollector.oldestUnseen, prometheus.GaugeValue, float64(timestampOldestUnseenInbox), metricnameOldestUnseenInbox...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.oldestUnseenOld, prometheus.GaugeValue, float64(timestampOldestUnseenInbox), metricnameOldestUnseenInbox...)
+				}
 			}
 
 			qc := quota.NewClient(c)
@@ -268,41 +363,65 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 				var metricnameMailboxQuotaUsed []string
 				metricnameMailboxQuotaUsed = append(metricnameMailboxQuotaUsed, metricMailboxQuotaUsed, namespaceMailboxQuotaUsed)
 				ch <- prometheus.MustNewConstMetric(valuecollector.mailboxQuotaUsed, prometheus.GaugeValue, float64(countMailboxQuotaUsed["MAILBOX_used"]), metricnameMailboxQuotaUsed...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.mailboxQuotaUsedOld, prometheus.GaugeValue, float64(countMailboxQuotaUsed["MAILBOX_used"]), metricnameMailboxQuotaUsed...)
+				}
 
 				metricMailboxQuotaAvail, namespaceMailboxQuotaAvail, _, countMailboxQuotaAvail := getMailboxUsed(qc, selectedInbox, valuecollector.logger, config.Accounts[account].Name)
 				var metricnameMailboxQuotaAvail []string
 				metricnameMailboxQuotaAvail = append(metricnameMailboxQuotaAvail, metricMailboxQuotaAvail, namespaceMailboxQuotaAvail)
 				ch <- prometheus.MustNewConstMetric(valuecollector.mailboxQuotaAvail, prometheus.GaugeValue, float64(countMailboxQuotaAvail["MAILBOX_avail"]), metricnameMailboxQuotaAvail...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.mailboxQuotaAvailOld, prometheus.GaugeValue, float64(countMailboxQuotaAvail["MAILBOX_avail"]), metricnameMailboxQuotaAvail...)
+				}
 
 				metricLevelQuotaUsed, namespaceLevelQuotaUsed, countLevelQuotaUsed, _ := getMailboxUsed(qc, selectedInbox, valuecollector.logger, config.Accounts[account].Name)
 				var metricnameLevelQuotaUsed []string
 				metricnameLevelQuotaUsed = append(metricnameLevelQuotaUsed, metricLevelQuotaUsed, namespaceLevelQuotaUsed)
 				ch <- prometheus.MustNewConstMetric(valuecollector.levelQuotaUsed, prometheus.GaugeValue, float64(countLevelQuotaUsed["LEVEL_used"]), metricnameLevelQuotaUsed...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.levelQuotaUsedOld, prometheus.GaugeValue, float64(countLevelQuotaUsed["LEVEL_used"]), metricnameLevelQuotaUsed...)
+				}
 
 				metricLevelQuotaAvail, namespaceLevelQuotaAvail, _, countLevelQuotaAvail := getMailboxUsed(qc, selectedInbox, valuecollector.logger, config.Accounts[account].Name)
 				var metricnameLevelQuotaAvail []string
 				metricnameLevelQuotaAvail = append(metricnameLevelQuotaAvail, metricLevelQuotaAvail, namespaceLevelQuotaAvail)
 				ch <- prometheus.MustNewConstMetric(valuecollector.levelQuotaAvail, prometheus.GaugeValue, float64(countLevelQuotaAvail["LEVEL_avail"]), metricnameLevelQuotaAvail...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.levelQuotaAvailOld, prometheus.GaugeValue, float64(countLevelQuotaAvail["LEVEL_avail"]), metricnameLevelQuotaAvail...)
+				}
 
 				metricStorageQuotaUsed, namespaceStorageQuotaUsed, countStorageQuotaUsed, _ := getMailboxUsed(qc, selectedInbox, valuecollector.logger, config.Accounts[account].Name)
 				var metricnameStorageQuotaUsed []string
 				metricnameStorageQuotaUsed = append(metricnameStorageQuotaUsed, metricStorageQuotaUsed, namespaceStorageQuotaUsed)
 				ch <- prometheus.MustNewConstMetric(valuecollector.storageQuotaUsed, prometheus.GaugeValue, float64(countStorageQuotaUsed["STORAGE_used"]), metricnameStorageQuotaUsed...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.storageQuotaUsedOld, prometheus.GaugeValue, float64(countStorageQuotaUsed["STORAGE_used"]/1000), metricnameStorageQuotaUsed...)
+				}
 
 				metricStorageQuotaAvail, namespaceStorageQuotaAvail, _, countStorageQuotaAvail := getMailboxUsed(qc, selectedInbox, valuecollector.logger, config.Accounts[account].Name)
 				var metricnameStorageQuotaAvail []string
 				metricnameStorageQuotaAvail = append(metricnameStorageQuotaAvail, metricStorageQuotaAvail, namespaceStorageQuotaAvail)
 				ch <- prometheus.MustNewConstMetric(valuecollector.storageQuotaAvail, prometheus.GaugeValue, float64(countStorageQuotaAvail["STORAGE_avail"]), metricnameStorageQuotaAvail...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.storageQuotaAvailOld, prometheus.GaugeValue, float64(countStorageQuotaAvail["STORAGE_avail"]/1000), metricnameStorageQuotaAvail...)
+				}
 
 				metricMessageQuotaUsed, namespaceMessageQuotaUsed, countMessageQuotaUsed, _ := getMailboxUsed(qc, selectedInbox, valuecollector.logger, config.Accounts[account].Name)
 				var metricnameMessageQuotaUsed []string
 				metricnameMessageQuotaUsed = append(metricnameMessageQuotaUsed, metricMessageQuotaUsed, namespaceMessageQuotaUsed)
 				ch <- prometheus.MustNewConstMetric(valuecollector.messageQuotaUsed, prometheus.GaugeValue, float64(countMessageQuotaUsed["MESSAGE_used"]), metricnameMessageQuotaUsed...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.messageQuotaUsedOld, prometheus.GaugeValue, float64(countMessageQuotaUsed["MESSAGE_used"]), metricnameMessageQuotaUsed...)
+				}
 
 				metricMessageQuotaAvail, namespaceMessageQuotaAvail, _, countMessageQuotaAvail := getMailboxUsed(qc, selectedInbox, valuecollector.logger, config.Accounts[account].Name)
 				var metricnameMessageQuotaAvail []string
 				metricnameMessageQuotaAvail = append(metricnameMessageQuotaAvail, metricMessageQuotaAvail, namespaceMessageQuotaAvail)
 				ch <- prometheus.MustNewConstMetric(valuecollector.messageQuotaAvail, prometheus.GaugeValue, float64(countMessageQuotaAvail["MESSAGE_avail"]), metricnameMessageQuotaAvail...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.messageQuotaAvailOld, prometheus.GaugeValue, float64(countMessageQuotaAvail["MESSAGE_avail"]), metricnameMessageQuotaAvail...)
+				}
 			}
 
 			for _, f := range config.Accounts[account].Folders {
@@ -320,19 +439,29 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 				var metricnameSeen []string
 				metricnameSeen = append(metricnameSeen, metricSeen, namespaceSeen)
 				ch <- prometheus.MustNewConstMetric(valuecollector.allMails, prometheus.GaugeValue, float64(countAllmails), metricnameSeen...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.allMailsOld, prometheus.GaugeValue, float64(countAllmails), metricnameSeen...)
+				}
 
 				metricUnseen, namespaceUnseen, countUnseenMails, _ := countUnseen(c, selected, valuecollector.logger, config.Accounts[account].Name, valuecollector.oldestunseenfeature)
 				var metricnameUnseen []string
 				metricnameUnseen = append(metricnameUnseen, metricUnseen, namespaceUnseen)
 				ch <- prometheus.MustNewConstMetric(valuecollector.unseenMails, prometheus.GaugeValue, float64(countUnseenMails), metricnameUnseen...)
+				if valuecollector.migrationmode {
+					ch <- prometheus.MustNewConstMetric(valuecollector.unseenMailsOld, prometheus.GaugeValue, float64(countUnseenMails), metricnameUnseen...)
+				}
 
 				metricOldestUnseen, namespaceOldestUnseen, _, timestampOldestUnseen := countUnseen(c, selected, valuecollector.logger, config.Accounts[account].Name, valuecollector.oldestunseenfeature)
 				if timestampOldestUnseen > 0 {
 					var metricnameOldestUnseen []string
 					metricnameOldestUnseen = append(metricnameOldestUnseen, metricOldestUnseen, namespaceOldestUnseen)
 					ch <- prometheus.MustNewConstMetric(valuecollector.oldestUnseen, prometheus.GaugeValue, float64(timestampOldestUnseen), metricnameOldestUnseen...)
+					if valuecollector.migrationmode {
+						ch <- prometheus.MustNewConstMetric(valuecollector.oldestUnseenOld, prometheus.GaugeValue, float64(timestampOldestUnseen), metricnameOldestUnseen...)
+					}
 				}
 			}
+			ch <- prometheus.MustNewConstMetric(valuecollector.fetchDuration, prometheus.GaugeValue, float64(time.Since(start).Seconds()), strings.ReplaceAll(strings.ReplaceAll(config.Accounts[account].Name, ".", "_"), " ", "_"))
 			level.Info(valuecollector.logger).Log("msg", "Metric fetch", "duration", time.Since(start), "address", config.Accounts[account].Mailaddress)
 		}(account)
 	}


### PR DESCRIPTION
To better use best practices in metric naming and avoid unreadable names I renamed the metrics. The old metrics are available as well by using a feature flag, so users can migrate.
with mailstat_fetch_duration_seconds I introduce a new maybe interesting metric.