### PR TITLE
feat: enable pprof profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased / xxxx-xx-xx
 
+* [FEATURE] enable pprof profiling from Go runtime https://github.com/bt909/imap-mailstat-exporter/pull/94
+
 * [CHORE] update module github.com/prometheus/common to from 0.56.0 to v0.57.0 https://github.com/bt909/imap-mailstat-exporter/pull/91
 * [CHORE] update module github.com/prometheus/common to from 0.57.0 to v0.58.0 https://github.com/bt909/imap-mailstat-exporter/pull/92
 * [CHORE] update update module github.com/prometheus/exporter-toolkit from v0.11.0 to v0.12.0 https://github.com/bt909/imap-mailstat-exporter/pull/93

--- a/cmd/imap-mailstat-exporter/main.go
+++ b/cmd/imap-mailstat-exporter/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"net/http"
+	"net/http/pprof"
 	"os"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -67,6 +68,11 @@ func main() {
 	reg.MustRegister(d)
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	promHandler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
 	mux.Handle(*metricsPath, promHandler)
 	if *metricsPath != "/" {


### PR DESCRIPTION
as exporter-toolkit v0.12.0 adds links for profiles to landing page, I should enable profiling to get this links useful