### PR TITLE
fix: adapt duration log entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased / XXXX-XX-XX
 
 * [CHANGE] adapt to slog logging which is introduced by exporter-toolkit https://github.com/bt909/imap-mailstat-exporter/pull/101
+* [CHANGE] adapt duration log entries to strings for json output like versions worked before switch to slog https://github.com/bt909/imap-mailstat-exporter/pull/104
 
 * [CHORE] update module github.com/prometheus/exporter-toolkit from v0.12.0 to v0.13.0 https://github.com/bt909/imap-mailstat-exporter/pull/101
 * [CHORE] update module github.com/prometheus/client_golang to from v1.20.3 to v1.20.4 https://github.com/bt909/imap-mailstat-exporter/pull/102

--- a/internal/valuecollect/valuecollector.go
+++ b/internal/valuecollect/valuecollector.go
@@ -236,7 +236,7 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 			} else {
 				c, err = client.DialTLS(serverconnection.String(), nil)
-				valuecollector.logger.Info("Connection setup", "duration", time.Since(start), "address", valuecollector.configfile.Accounts[account].Mailaddress)
+				valuecollector.logger.Info("Connection setup", "duration", time.Since(start).String(), "address", valuecollector.configfile.Accounts[account].Mailaddress)
 				if err != nil {
 					valuecollector.logger.Error("Failed to dial server via TLS", "address", valuecollector.configfile.Accounts[account].Mailaddress, "server", valuecollector.configfile.Accounts[account].Serveraddress)
 					up = 0
@@ -252,7 +252,7 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 				up = 0
 				return
 			}
-			valuecollector.logger.Info("IMAP login", "duration", time.Since(startLogin), "address", valuecollector.configfile.Accounts[account].Mailaddress, "server", valuecollector.configfile.Accounts[account].Serveraddress)
+			valuecollector.logger.Info("IMAP login", "duration", time.Since(startLogin).String(), "address", valuecollector.configfile.Accounts[account].Mailaddress, "server", valuecollector.configfile.Accounts[account].Serveraddress)
 
 			defer c.Logout()
 
@@ -357,7 +357,7 @@ func (valuecollector *imapStatsCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 			}
 			ch <- prometheus.MustNewConstMetric(valuecollector.fetchDuration, prometheus.GaugeValue, float64(time.Since(start).Seconds()), strings.ReplaceAll(strings.ReplaceAll(valuecollector.configfile.Accounts[account].Name, ".", "_"), " ", "_"))
-			valuecollector.logger.Info("Metric fetch", "duration", time.Since(start), "address", valuecollector.configfile.Accounts[account].Mailaddress)
+			valuecollector.logger.Info("Metric fetch", "duration", time.Since(start).String(), "address", valuecollector.configfile.Accounts[account].Mailaddress)
 		}(account)
 	}
 	wg.Wait()


### PR DESCRIPTION
use strings as duration output, to get duration values and units in json output like it worked in versions before switch to slog